### PR TITLE
typo fix

### DIFF
--- a/src/bin/day_06.rs
+++ b/src/bin/day_06.rs
@@ -4,7 +4,7 @@ fn main() {
     let input = include_str!("../../puzzle_inputs/day_06.txt");
     let input: Vec<char> = input.chars().collect();
     println!("day 6a: {} (1235)", solve(&input, 4));
-    println!("day 6b: {} (3501)", solve(&input, 14));
+    println!("day 6b: {} (3051)", solve(&input, 14));
 }
 
 fn solve(input: &[char], window_len: usize) -> usize {


### PR DESCRIPTION
When I run your solution of [`day 6`](https://github.com/treuille/advent-of-code-2022-in-rust/blob/14e573335f91b2b8ed7d6c1acc6cf4a16c60a1eb/src/bin/day_06.rs), I get the following output:
```
day 6a: 1235 (1235)
day 6b: 3051 (3501)
```
I guess there is a typo in the line:
https://github.com/treuille/advent-of-code-2022-in-rust/blob/14e573335f91b2b8ed7d6c1acc6cf4a16c60a1eb/src/bin/day_06.rs#L7

My solution for your input data also returns `3051`.